### PR TITLE
Fix issues with JSON format and handling of non-existing file

### DIFF
--- a/pyOneNote/Main.py
+++ b/pyOneNote/Main.py
@@ -24,7 +24,7 @@ def process_onenote_file(file, output_dir, extension, json_output):
         exit()
 
     file.seek(0)
-    document = OneDocment(file)
+    document = OneDocument(file)
     data = document.get_json()
     if not json_output:
         print('Headers\n####################################################################')

--- a/pyOneNote/Main.py
+++ b/pyOneNote/Main.py
@@ -81,7 +81,7 @@ def main():
     args = p.parse_args()
 
     if not os.path.exists(args.file):
-        sys.exit("File: %s doesn't exist", args.file)
+        sys.exit("File: '{}' doesn't exist".format(args.file))
 
     with open(args.file, "rb") as file:
         process_onenote_file(file, args.output_dir, args.extension, args.json)

--- a/pyOneNote/Main.py
+++ b/pyOneNote/Main.py
@@ -58,8 +58,8 @@ def process_onenote_file(file, output_dir, extension, json_output):
             ) as output_file:
                 output_file.write(file["content"])
             counter += 1
-
-    return json.dumps(document.get_json())
+    else:
+        print(json.dumps(data))
 
 
 def get_hex_format(hex_str, col, indent):

--- a/pyOneNote/OneDocument.py
+++ b/pyOneNote/OneDocument.py
@@ -3,7 +3,7 @@ from pyOneNote.FileNode import *
 import json
 
 
-class OneDocment:
+class OneDocument:
     def __init__(self, file):
         self.header = Header(file)
         self.root_file_node_list = FileNodeList(file, self.header.fcrFileNodeListRoot)
@@ -19,7 +19,7 @@ class OneDocment:
                     nodes.append(file_node)
 
                 for child_file_node_list in file_node.children:
-                    OneDocment.traverse_nodes(child_file_node_list, nodes, filters)
+                    OneDocument.traverse_nodes(child_file_node_list, nodes, filters)
 
     def get_properties(self):
         if self._properties:
@@ -29,7 +29,7 @@ class OneDocment:
 
         self._properties = []
 
-        OneDocment.traverse_nodes(self.root_file_node_list, nodes, filters)
+        OneDocument.traverse_nodes(self.root_file_node_list, nodes, filters)
         for node in nodes:
             if hasattr(node, 'propertySet'):
                 node.propertySet.body.indent= '\t\t'
@@ -44,7 +44,7 @@ class OneDocment:
         self._files = {}
         filters = ["FileDataStoreObjectReferenceFND", "ObjectDeclarationFileData3RefCountFND"]
 
-        OneDocment.traverse_nodes(self.root_file_node_list, nodes, filters)
+        OneDocument.traverse_nodes(self.root_file_node_list, nodes, filters)
 
         for node in nodes:
             if hasattr(node, "data") and node.data:


### PR DESCRIPTION
Hi, I stumbled upon three issues. They are independent, but I think they are too small, so making three separate PRs seems unnecessary to me.

1. JSON can not be printed
`process_onenote_file` does not print document in JSON if `json_output` parameter is set. Instead, it always returns it. This return value is not even used in the main.
This fork fixes use of `json_output` parameter. If `True`, `process_onenote_file` will print document in JSON form instead of the default text form. The default text form will be used otherwise. No value will be returned.
    ```console
    $ git checkout 74d7b05  # upstream main
    $ pyonenote --json --file <any_onenote_file>
    $ # nothing
    $ git checkout e363ca6  # forked main
    $ pyonenote --json --file <any_onenote_file>
    {"headers": {"guidFileType": ...
    ```
2.  Fix typo `OneDocment` -> `OneDocument`
    I think it was not intended at least based on the module's name.
4. Fix handling of non-existing file
    ```console
    $ git checkout 74d7b05  # upstream main
    $ pyonenote --file nonexisting_file
    Traceback (most recent call last):
      File "/home/user/pyOneNote/virtualenv/bin/pyonenote", line 33, in <module>
        sys.exit(load_entry_point('pyOneNote', 'console_scripts', 'pyonenote')())
      File "/home/user/pyOneNote/pyOneNote/Main.py", line 84, in main
        sys.exit("File: %s doesn't exist", args.file)
    TypeError: exit expected at most 1 argument, got 2
    $ git checkout e363ca6  # forked main
    $ pyonenote --file nonexisting_file
    File: 'nonexisting_file' doesn't exist
    ```